### PR TITLE
CO-9629: replace override by normal

### DIFF
--- a/providers/connection.rb
+++ b/providers/connection.rb
@@ -14,7 +14,7 @@ action :create do
   )
   exist = Mash.new(node[:stunnel][:services][new_resource.service_name])
   if(exist != hsh)
-    node.override[:stunnel][:services][new_resource.service_name] = hsh
+    node.normal[:stunnel][:services][new_resource.service_name] = hsh
     new_resource.updated_by_last_action(true)
   end
 end
@@ -22,7 +22,7 @@ end
 action :delete do
   serv_data = Mash.new(node[:stunnel][:services])
   if(serv_data.delete(new_resource.service_name))
-    node.override[:stunnel][:services] = serv_data
+    node.normal[:stunnel][:services] = serv_data
     new_resource.updated_by_last_action(true)
   end
 end


### PR DESCRIPTION
[Risk Level label][1] 

## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CO-9629)

## Code reviewers

- [ ] @pkazi 
- [ ] @pallav-jakhotiya  


## Summary

Stunnel service was getting restarted with every chef-client run as it was unable to set the node attribute **node[:stunnel][:services][service_name]**.

## Summary of change

Replaced the **default** type with **normal** in provider script.

## Testing approach

- [x] Manual test
- [ ] No test (please specify why)